### PR TITLE
Fix for accounts with orders that are not vehicles. 

### DIFF
--- a/src/rivian_python_api/rivian_cli.py
+++ b/src/rivian_python_api/rivian_cli.py
@@ -118,8 +118,9 @@ def order_details(order_id, verbose):
         'model': response_json['data']['order']['vehicle']['model'],
     }
     for i in response_json['data']['order']['items']:
-        for c in i['configuration']['options']:
-            data[c['groupName']] = c['optionName']
+        if i['configuration'] is not None:
+            for c in i['configuration']['options']:
+                data[c['groupName']] = c['optionName']
     return data
 
 


### PR DESCRIPTION
 The account I'm using for testing has a wall charger as the first order which is an "accessory" order type.  This order type does not have a configuration field so an exception is thrown when attempting to get [configuration][options].