### PR TITLE
Fix minor typo in trip planning example that routed to an unintended destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ bin/rivian_cli --poll
 ### Trip planning
 Plan trip will create a basic visualization of the route and charge stops. MAPBOX_API_KEY needs to be set in `.env`
 ```
-bin/rivian_cli --plan_trip 85,225,40.5112,-89.0559,39.9310,-104.9530
+bin/rivian_cli --plan_trip 85,225,40.5112,-89.0559,39.7706,-104.9530
 ```
 
 ### Other commands


### PR DESCRIPTION
Ran the example and it was accidentally the wrong example latitude 