### PR TITLE
fix up error when manually specifying vehicle_id

### DIFF
--- a/src/rivian_python_api/rivian_cli.py
+++ b/src/rivian_python_api/rivian_cli.py
@@ -537,6 +537,8 @@ def main():
         distance_units_string = "mph"
 
     vehicle_id = None
+    if args.vehicle_id:
+        vehicle_id = args.vehicle_id
 
     needs_vehicle = args.vehicles or \
                     args.vehicle or \


### PR DESCRIPTION
Started playing around with the `rivian_cli`, but - I'm getting errors with querying vehicle order data (1 delivered r1t, 1 post price hike r1s). No matter - figured I'd test out the vehicle state - that's more what I'm curious about anyway 😉. However, I got an error, as I found out - vehicle_id isn't set when specified manually. This PR rectifies this situation for me.