### PR TITLE
Don't print empty HardwareFailureStatuses

### DIFF
--- a/src/rivian_python_api/rivian_cli.py
+++ b/src/rivian_python_api/rivian_cli.py
@@ -1048,10 +1048,14 @@ def main():
             print(f"      Rear Left: {state['tirePressureStatusRearLeft']['value']}")
             print(f"      Rear Right: {state['tirePressureStatusRearRight']['value']}")
             print(f"   12V Battery: {state['twelveVoltBatteryHealth']['value']}")
-            print(f"   btmFf Hardware Failure Status {state['btmFfHardwareFailureStatus']['value']}")
-            print(f"   btmIc Hardware Failure Status {state['btmIcHardwareFailureStatus']['value']}")
-            print(f"   btmLfd Hardware Failure Status {state['btmLfdHardwareFailureStatus']['value']}")
-            print(f"   btmRfd Hardware Failure Status {state['btmRfdHardwareFailureStatus']['value']}")
+            if state['btmFfHardwareFailureStatus']:
+                print(f"   btmFf Hardware Failure Status {state['btmFfHardwareFailureStatus']['value']}")
+            if state['btmIcHardwareFailureStatus']:
+                print(f"   btmIc Hardware Failure Status {state['btmIcHardwareFailureStatus']['value']}")
+            if state['btmLfdHardwareFailureStatus']:
+                print(f"   btmLfd Hardware Failure Status {state['btmLfdHardwareFailureStatus']['value']}")
+            if state['btmRfdHardwareFailureStatus']:
+                print(f"   btmRfd Hardware Failure Status {state['btmRfdHardwareFailureStatus']['value']}")
 
     if args.poll or args.query or args.all:
         single_poll = args.query or args.all
@@ -1162,7 +1166,7 @@ def main():
             if len(args.plan_trip.split(',')) == 4:
                 starting_soc, starting_range, origin_place, dest_place = args.plan_trip.split(',')
                 origin_lat, origin_long = extract_lat_long(origin_place)
-                dest_lat, dest_long = extract_lat_long(dest_place) 
+                dest_lat, dest_long = extract_lat_long(dest_place)
             else:
                 starting_soc, starting_range, origin_lat, origin_long, dest_lat, dest_long = args.plan_trip.split(',')
 


### PR DESCRIPTION
When running `./bin/rivian_cli --state`, I was running into errors like this:

```shell
% ./bin/rivian_cli --state
Vehicle State:
Power State: sleep
...
Maintenance:
   Service Mode: off
   Car Wash Mode: off
   Wiper Fluid: normal
   Tire pressures:
      Front Left: OK
      Front Right: OK
      Rear Left: OK
      Rear Right: OK
   12V Battery: NORMAL_OPERATION
Traceback (most recent call last):
  File "/Users/matt/projects/rivian-python-api/src/rivian_python_api/rivian_cli.py", line 1278, in <module>
    main()
    ~~~~^^
  File "/Users/matt/projects/rivian-python-api/src/rivian_python_api/rivian_cli.py", line 1051, in main
    print(f"   btmFf Hardware Failure Status {state['btmFfHardwareFailureStatus']['value']}")
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

This check to see if the hardware statuses are `None` works around it.